### PR TITLE
Object.keys fails when this.errors is null

### DIFF
--- a/lib/error/validation.js
+++ b/lib/error/validation.js
@@ -46,7 +46,7 @@ ValidationError.prototype.toString = function() {
   var ret = this.name + ': ';
   var msgs = [];
 
-  Object.keys(this.errors).forEach(function(key) {
+  Object.keys(this.errors || {}).forEach(function(key) {
     if (this === this.errors[key]) {
       return;
     }


### PR DESCRIPTION
In ValidationError.toString, the Object.keys fails when this.errors is null. Fixes #4689